### PR TITLE
19-oncopy-function-overwrites-selected-fields fix copy content

### DIFF
--- a/src/components/Editor/SuggestionElementList/SuggestionElementList.tsx
+++ b/src/components/Editor/SuggestionElementList/SuggestionElementList.tsx
@@ -198,7 +198,13 @@ export const SuggestionElementList = forwardRef<HTMLDivElement, Props>((props, r
   }, [isOpen, focusableElement, elements.length]);
 
   return (
-    <div className={cx(s.dropdown, 'yopta-suggestion_list')} role="dialog" aria-modal="true" ref={ref} style={style}>
+    <div
+      className={cx(s.dropdown, 'yopta-suggestion_list yopta-tools')}
+      role="dialog"
+      aria-modal="true"
+      ref={ref}
+      style={style}
+    >
       <ul className={s.elementList} ref={elementListRef}>
         {elements.map((element, i) => (
           <li

--- a/src/components/Editor/Toolbar/Toolbar.tsx
+++ b/src/components/Editor/Toolbar/Toolbar.tsx
@@ -64,7 +64,7 @@ const Toolbar = ({ editor }: ToolbarProps) => {
     <div
       ref={toolbarRef}
       role="tooltip"
-      className={cx(s.menu, 'yopta-toolbar')}
+      className={cx(s.menu, 'yopta-toolbar yopta-tools')}
       style={toolbarStyle}
       contentEditable={false}
     >
@@ -82,9 +82,7 @@ const Toolbar = ({ editor }: ToolbarProps) => {
           {selectedElement?.name}
         </button>
         <button type="button" className={cx(s.button, !!linkNode && s.__active)} onMouseDown={toggleLinkInput}>
-          <LinkIcon />
-          {' '}
-          <span>Link</span>
+          <LinkIcon /> <span>Link</span>
         </button>
         <button
           type="button"

--- a/src/components/ImageEditor/index.tsx
+++ b/src/components/ImageEditor/index.tsx
@@ -151,7 +151,7 @@ const ImageEditor: FC<Props> = ({ element, attributes, className, children }) =>
         {optimistic && dataSrc ? (
           loader
         ) : (
-          <div className={s.options}>
+          <div className={cx(s.options, 'yopta-tools')}>
             <MediaEditorOptions
               hasUrl={!!element.src}
               handleDelete={onDelete}

--- a/src/components/NodeSettings/NodeSettings.tsx
+++ b/src/components/NodeSettings/NodeSettings.tsx
@@ -70,7 +70,7 @@ const NodeSettings = ({
 
   return (
     <div
-      className={cx(s.actionItems, 'node-settings-actions', {
+      className={cx(s.actionItems, 'node-settings-actions yopta-tools', {
         [s.actionItemsShow]: isHovered,
         [s.nestedItems]: isNestedNode,
       })}

--- a/src/components/VideoEditor/VideoEditor.tsx
+++ b/src/components/VideoEditor/VideoEditor.tsx
@@ -168,7 +168,7 @@ const VideoEditor: FC<Props> = ({ element, attributes, className, children }) =>
   return (
     <div draggable={false} {...attributes} contentEditable={false} className={className}>
       {linkNode}
-      <div className={s.options}>
+      <div className={cx(s.options, 'yopta-tools')}>
         <MediaEditorOptions
           hasUrl={!!element.src}
           handleDelete={onDelete}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,19 +41,23 @@ export function isValidYoptaNodes(nodes: any): boolean {
 }
 
 // copy function for parent <div /> of nodes
-export function onCopyYoptaNodes(e: ClipboardEvent) {
-  e.preventDefault();
-  e.stopPropagation();
+export function onCopyYoptaNodes(event: ClipboardEvent) {
+  event.preventDefault();
+  event.stopPropagation();
 
-  const div = document.createElement('div');
-  div.innerHTML = e.currentTarget.innerHTML;
+  const range = window.getSelection()!.getRangeAt(0);
+  const content = range.cloneContents();
 
-  // [TODO] - add common classname to every tool for additional check
-  const yoptaTools = div.querySelectorAll('.node-settings-actions');
+  const div = content?.ownerDocument.createElement('div');
+  div?.appendChild(content);
 
-  if (yoptaTools.length > 0) {
-    div.querySelectorAll('.node-settings-actions').forEach((el) => el?.remove());
+  const yoptaTools = div.querySelectorAll('.yopta-tools');
+
+  if (yoptaTools && yoptaTools.length > 0) {
+    yoptaTools.forEach((el) => el?.remove());
   }
 
-  e.clipboardData.setData('text/html', div.innerHTML);
+  event.clipboardData.setData('text/html', div.innerHTML);
+
+  return event.clipboardData;
 }


### PR DESCRIPTION
Fixed onCopy function for YoptaRenderer and YoptaEditor.
Copy only selected fields of content